### PR TITLE
Convert record modals to sheets

### DIFF
--- a/src/admin/records.rs
+++ b/src/admin/records.rs
@@ -36,6 +36,10 @@ pub(super) struct RecordLabel {
 pub(super) struct RecordEntry {
     pub uri: String,
     pub did: String,
+    pub collection: String,
+    pub rkey: String,
+    pub cid: String,
+    pub indexed_at: Option<String>,
     pub record: Value,
     pub labels: Vec<RecordLabel>,
 }
@@ -46,6 +50,16 @@ pub(super) struct ListRecordsResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
 }
+
+type RecordRow = (
+    String,
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    String,
+);
 
 /// GET /admin/records?collection=X&limit=N&cursor=C — browse records by collection.
 pub(super) async fn list_records(
@@ -63,10 +77,10 @@ pub(super) async fn list_records(
         .unwrap_or(0);
 
     let sql = adapt_sql(
-        "SELECT uri, did, record FROM records WHERE collection = ? ORDER BY indexed_at DESC LIMIT ? OFFSET ?",
+        "SELECT uri, did, collection, rkey, cid, indexed_at, record FROM records WHERE collection = ? ORDER BY indexed_at DESC LIMIT ? OFFSET ?",
         backend,
     );
-    let rows: Vec<(String, String, String)> = sqlx::query_as(&sql)
+    let rows: Vec<RecordRow> = sqlx::query_as(&sql)
         .bind(&params.collection)
         .bind(limit + 1)
         .bind(offset)
@@ -75,13 +89,12 @@ pub(super) async fn list_records(
         .map_err(|e| AppError::Internal(format!("failed to list records: {e}")))?;
 
     let has_more = rows.len() as i64 > limit;
-    let visible_rows: Vec<(String, String, String)> =
-        rows.into_iter().take(limit as usize).collect();
+    let visible_rows: Vec<RecordRow> = rows.into_iter().take(limit as usize).collect();
 
     // Batch-query external labels for all visible URIs
     let uris: Vec<&str> = visible_rows
         .iter()
-        .map(|(uri, _, _)| uri.as_str())
+        .map(|(uri, _, _, _, _, _, _)| uri.as_str())
         .collect();
 
     let label_rows: Vec<(String, String, String, String)> = if uris.is_empty() {
@@ -114,34 +127,40 @@ pub(super) async fn list_records(
 
     let records: Vec<RecordEntry> = visible_rows
         .into_iter()
-        .map(|(uri, did, record_str)| {
-            let record: Value = serde_json::from_str(&record_str).unwrap_or_default();
-            let mut labels = labels_by_uri.remove(&uri).unwrap_or_default();
+        .map(
+            |(uri, did, collection, rkey, cid, indexed_at, record_str)| {
+                let record: Value = serde_json::from_str(&record_str).unwrap_or_default();
+                let mut labels = labels_by_uri.remove(&uri).unwrap_or_default();
 
-            // Extract self-labels from record JSONB
-            if let Some(values) = record
-                .get("labels")
-                .and_then(|l| l.get("values"))
-                .and_then(|v| v.as_array())
-            {
-                for entry in values {
-                    if let Some(val) = entry.get("val").and_then(|v| v.as_str()) {
-                        labels.push(RecordLabel {
-                            src: did.clone(),
-                            val: val.to_string(),
-                            cts: String::new(),
-                        });
+                // Extract self-labels from record JSONB
+                if let Some(values) = record
+                    .get("labels")
+                    .and_then(|l| l.get("values"))
+                    .and_then(|v| v.as_array())
+                {
+                    for entry in values {
+                        if let Some(val) = entry.get("val").and_then(|v| v.as_str()) {
+                            labels.push(RecordLabel {
+                                src: did.clone(),
+                                val: val.to_string(),
+                                cts: String::new(),
+                            });
+                        }
                     }
                 }
-            }
 
-            RecordEntry {
-                uri,
-                did,
-                record,
-                labels,
-            }
-        })
+                RecordEntry {
+                    uri,
+                    did,
+                    collection,
+                    rkey,
+                    cid,
+                    indexed_at,
+                    record,
+                    labels,
+                }
+            },
+        )
         .collect();
 
     let cursor = if has_more {

--- a/web/src/app/dashboard/records/page.tsx
+++ b/web/src/app/dashboard/records/page.tsx
@@ -28,6 +28,12 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CodeBlock } from "@/components/code-block";
 import { DataTable } from "@/components/data-table/data-table";
@@ -430,29 +436,87 @@ export default function RecordsPage() {
           </div>
         )}
 
-        {viewRecord && (
-          <ResponsiveDialog open onOpenChange={() => setViewRecord(null)}>
-            <ResponsiveDialogContent className="sm:max-w-4xl">
-              <ResponsiveDialogHeader>
-                <ResponsiveDialogTitle className="truncate font-mono text-sm">
-                  {viewRecord.uri}
-                </ResponsiveDialogTitle>
-              </ResponsiveDialogHeader>
-              <CodeBlock code={JSON.stringify(viewRecord, null, 2)} />
-              {hasPermission("records:delete") && (
-                <div className="flex justify-end">
-                  <Button
-                    variant="destructive"
-                    onClick={() => setDeleteUri(viewRecord.uri)}
-                    disabled={deleting}
-                  >
-                    {deleting ? "Deleting..." : "Delete Record"}
-                  </Button>
+        <Sheet
+          open={viewRecord != null}
+          onOpenChange={(open) => {
+            if (!open) setViewRecord(null);
+          }}
+        >
+          <SheetContent className="sm:max-w-xl overflow-hidden flex flex-col">
+            {viewRecord && (
+              <>
+                <SheetHeader>
+                  <SheetTitle className="sr-only">Record Detail</SheetTitle>
+                </SheetHeader>
+                <div className="flex-1 min-h-0 overflow-y-auto px-4 flex flex-col gap-4">
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div className="col-span-2">
+                      <span className="text-muted-foreground">URI</span>
+                      <p className="font-mono text-xs break-all">{viewRecord.uri}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">DID</span>
+                      <p className="font-mono text-xs break-all">{viewRecord.did}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Collection</span>
+                      <p className="font-mono text-xs">{viewRecord.collection}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Record Key</span>
+                      <p className="font-mono text-xs">{viewRecord.rkey}</p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">CID</span>
+                      <p className="font-mono text-xs break-all">{viewRecord.cid}</p>
+                    </div>
+                    {viewRecord.indexed_at && (
+                      <div>
+                        <span className="text-muted-foreground">Indexed</span>
+                        <p className="text-xs">
+                          {new Date(viewRecord.indexed_at).toLocaleString()}
+                        </p>
+                      </div>
+                    )}
+                    {viewRecord.labels.length > 0 && (
+                      <div className="col-span-2">
+                        <span className="text-muted-foreground">Labels</span>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {viewRecord.labels.map((l, i) => (
+                            <span
+                              key={i}
+                              className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs"
+                            >
+                              {l.val}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col flex-1 min-h-0">
+                    <span className="text-muted-foreground text-sm">Record</span>
+                    <div className="mt-1">
+                      <CodeBlock code={JSON.stringify(viewRecord.record, null, 2)} />
+                    </div>
+                  </div>
                 </div>
-              )}
-            </ResponsiveDialogContent>
-          </ResponsiveDialog>
-        )}
+                {hasPermission("records:delete") && (
+                  <div className="flex justify-end border-t p-4">
+                    <Button
+                      variant="destructive"
+                      onClick={() => setDeleteUri(viewRecord.uri)}
+                      disabled={deleting}
+                    >
+                      {deleting ? "Deleting..." : "Delete Record"}
+                    </Button>
+                  </div>
+                )}
+              </>
+            )}
+          </SheetContent>
+        </Sheet>
 
         <ResponsiveDialog
           open={!!deleteUri}

--- a/web/src/types/records.ts
+++ b/web/src/types/records.ts
@@ -7,6 +7,10 @@ export interface RecordLabel {
 export interface AdminRecord {
   uri: string
   did: string
+  collection: string
+  rkey: string
+  cid: string
+  indexed_at: string | null
   record: Record<string, unknown>
   labels: RecordLabel[]
 }


### PR DESCRIPTION
Updates the records page to use `<Sheet>` components instead of modals. This gives the content much more vertical space without hacky sizing tricks.

Fixes #25.