### PR TITLE
Prevent dead letters from being created without IDs

### DIFF
--- a/migrations/postgres/20260512000000_fix_null_dead_letter_ids.sql
+++ b/migrations/postgres/20260512000000_fix_null_dead_letter_ids.sql
@@ -1,0 +1,1 @@
+UPDATE dead_letter_hooks SET id = gen_random_uuid() WHERE id IS NULL;

--- a/migrations/sqlite/20260512000000_fix_null_dead_letter_ids.sql
+++ b/migrations/sqlite/20260512000000_fix_null_dead_letter_ids.sql
@@ -1,0 +1,1 @@
+UPDATE dead_letter_hooks SET id = lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))) WHERE id IS NULL;

--- a/src/lua/execute.rs
+++ b/src/lua/execute.rs
@@ -957,12 +957,13 @@ pub async fn execute_hook_script(event: &HookEvent<'_>) -> Option<Value> {
         .map(|r| serde_json::to_string(r).unwrap_or_default());
     let dead_letter_sql = adapt_sql(
         r#"
-        INSERT INTO dead_letter_hooks (lexicon_id, uri, did, collection, rkey, action, record, error, attempts, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO dead_letter_hooks (id, lexicon_id, uri, did, collection, rkey, action, record, error, attempts, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
         backend,
     );
     if let Err(e) = sqlx::query(&dead_letter_sql)
+        .bind(uuid::Uuid::new_v4().to_string())
         .bind(event.lexicon_id)
         .bind(event.uri)
         .bind(event.did)


### PR DESCRIPTION
In some scenarios dead letters could be created without IDs. I've identified the source of that, and added a mitigation to add IDs to dead letters that were missing them.

Fixes #20.