### PR TITLE
feat: add includeValues option to listRecords

### DIFF
--- a/src/spaces/routes.rs
+++ b/src/spaces/routes.rs
@@ -126,6 +126,7 @@ struct ListRecordsQuery {
     limit: Option<i64>,
     cursor: Option<String>,
     reverse: Option<bool>,
+    include_values: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -789,14 +790,19 @@ async fn list_records(
     )
     .await?;
 
+    let include_values = query.include_values.unwrap_or(false);
     let records_json: Vec<serde_json::Value> = records
         .into_iter()
         .map(|r| {
-            serde_json::json!({
+            let mut rec = serde_json::json!({
                 "collection": r.collection,
                 "rkey": r.rkey,
                 "cid": r.cid,
-            })
+            });
+            if include_values {
+                rec["value"] = r.record;
+            }
+            rec
         })
         .collect();
 


### PR DESCRIPTION
hey! happyview seems great so far. I believe I need to be able to include the values from listRecords to pull lists of tasks for chalky.town. This just adds that support.

related lexicon: https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/repo/listRecords.json