### PR TITLE
fix: use correct page name for record/label scripts page

### DIFF
--- a/packages/docs/content/blog/happyview-2.9.md
+++ b/packages/docs/content/blog/happyview-2.9.md
@@ -33,7 +33,7 @@ Scripts are managed through the dashboard under **Settings > Scripts**, or via t
 
 **If you're upgrading from v2.x to v2.9:** existing index hooks and lexicon scripts will be migrated to the new system automatically.
 
-Full docs: [Record & Label Scripts](/guides/label-scripts), [Lua Scripting](/guides/lua-scripting), [Admin API — Scripts](/api-reference/admin/scripts).
+Full docs: [Record & Label Scripts](/guides/record-scripts), [Lua Scripting](/guides/lua-scripting), [Admin API — Scripts](/api-reference/admin/scripts).
 
 ## Backfill, but concurrent
 

--- a/packages/docs/content/docs/api-reference/lua/atproto-api.md
+++ b/packages/docs/content/docs/api-reference/lua/atproto-api.md
@@ -2,7 +2,7 @@
 title: "atproto API"
 ---
 
-The `atproto` table provides atproto utility functions. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts).
+The `atproto` table provides atproto utility functions. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts).
 
 ## atproto.resolve_service_endpoint
 

--- a/packages/docs/content/docs/api-reference/lua/database-api.md
+++ b/packages/docs/content/docs/api-reference/lua/database-api.md
@@ -2,7 +2,7 @@
 title: "Database API"
 ---
 
-The `db` table provides access to the database. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts).
+The `db` table provides access to the database. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts).
 
 ## db.query
 

--- a/packages/docs/content/docs/api-reference/lua/http-api.md
+++ b/packages/docs/content/docs/api-reference/lua/http-api.md
@@ -2,7 +2,7 @@
 title: "HTTP API"
 ---
 
-The `http` table provides async HTTP client functions. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts).
+The `http` table provides async HTTP client functions. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts).
 
 ## Methods
 

--- a/packages/docs/content/docs/api-reference/lua/json-api.md
+++ b/packages/docs/content/docs/api-reference/lua/json-api.md
@@ -2,7 +2,7 @@
 title: "JSON API"
 ---
 
-The `json` global provides JSON serialization and deserialization. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts).
+The `json` global provides JSON serialization and deserialization. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts).
 
 ## json.encode
 

--- a/packages/docs/content/docs/api-reference/lua/utility-globals.md
+++ b/packages/docs/content/docs/api-reference/lua/utility-globals.md
@@ -2,7 +2,7 @@
 title: "Utility Globals"
 ---
 
-Global functions available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts). These don't belong to a specific API table — they're available at the top level of any script.
+Global functions available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts). These don't belong to a specific API table — they're available at the top level of any script.
 
 ## now
 

--- a/packages/docs/content/docs/api-reference/lua/xrpc-lua-api.md
+++ b/packages/docs/content/docs/api-reference/lua/xrpc-lua-api.md
@@ -2,7 +2,7 @@
 title: "XRPC Lua API"
 ---
 
-The `xrpc` table provides cross-endpoint XRPC calls. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/label-scripts).
+The `xrpc` table provides cross-endpoint XRPC calls. Available in all [Lua scripts](../../guides/lua-scripting.md) — queries, procedures, and [record/label scripts](../../guides/record-scripts).
 
 ## xrpc.query
 

--- a/packages/docs/content/docs/guides/api-keys.md
+++ b/packages/docs/content/docs/guides/api-keys.md
@@ -109,4 +109,4 @@ The **Last Used** column in the API Keys table shows when each key was last used
 
 - [Admin API reference](../api-reference/admin/admin-api.md) — full endpoint documentation
 - [Scripting](./lua-scripting.md) — automate record processing with Lua scripts
-- [Record & label scripts](./label-scripts) — react to record changes and label events
+- [Record & label scripts](./record-scripts) — react to record changes and label events

--- a/packages/docs/content/docs/guides/event-logs.md
+++ b/packages/docs/content/docs/guides/event-logs.md
@@ -81,7 +81,7 @@ Logged when a user attempts to access an endpoint they don't have permission for
 | `script.executed`      | info     | Trigger ID | `trigger_id`          |
 | `script.dead_lettered` | error    | Trigger ID | `trigger_id`, `error` |
 
-Logged when [record/label scripts](./label-scripts) run. Dead-lettered events indicate a script failed all retry attempts. You can manage dead letters from the **Data > Dead Letters** page in the dashboard — see [Dead Letters](#dead-letters) below.
+Logged when [record/label scripts](./record-scripts) run. Dead-lettered events indicate a script failed all retry attempts. You can manage dead letters from the **Data > Dead Letters** page in the dashboard — see [Dead Letters](#dead-letters) below.
 
 ### Backfill events
 

--- a/packages/docs/content/docs/guides/lexicons.md
+++ b/packages/docs/content/docs/guides/lexicons.md
@@ -10,7 +10,7 @@ You don't write route handlers or database queries; you upload a lexicon and Hap
 
 | Type          | Effect                                                                                                                                   |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `record`      | Adds the collection to the Jetstream subscription filter and indexes records into the database. Supports [record scripts](label-scripts) |
+| `record`      | Adds the collection to the Jetstream subscription filter and indexes records into the database. Supports [record scripts](record-scripts) |
 | `query`       | Registers a `GET /xrpc/{nsid}` endpoint that queries indexed records                                                                     |
 | `procedure`   | Registers a `POST /xrpc/{nsid}` endpoint that proxies writes to the user's PDS                                                           |
 | `definitions` | Stored but does not generate routes or subscriptions                                                                                     |
@@ -102,7 +102,7 @@ In short: if you want to serve an XRPC method on your instance, you need a local
 ## Next steps
 
 - [Lua Scripting](./lua-scripting.md): Add custom query and procedure logic to your endpoints
-- [Record & Label Scripts](label-scripts): Run Lua scripts when records are indexed or labels arrive
+- [Record & Label Scripts](record-scripts): Run Lua scripts when records are indexed or labels arrive
 - [XRPC API](../api-reference/xrpc-api.md): Understand how the generated endpoints behave
 - [Backfill](backfill.md): Learn how historical records are indexed
 - [Admin API](../api-reference/admin/admin-api.md): Full reference for lexicon management endpoints

--- a/packages/docs/content/docs/guides/lua-scripting.md
+++ b/packages/docs/content/docs/guides/lua-scripting.md
@@ -2,7 +2,7 @@
 title: "Lua Scripting"
 ---
 
-Without Lua scripts, HappyView's query endpoints return raw records and procedure endpoints proxy simple creates and updates. To attach a script to an XRPC endpoint, create a script with trigger `xrpc.query:<nsid>` or `xrpc.procedure:<nsid>` — see [trigger grammar](label-scripts#trigger-grammar). Lua scripts let you go much further:
+Without Lua scripts, HappyView's query endpoints return raw records and procedure endpoints proxy simple creates and updates. To attach a script to an XRPC endpoint, create a script with trigger `xrpc.query:<nsid>` or `xrpc.procedure:<nsid>` — see [trigger grammar](record-scripts#trigger-grammar). Lua scripts let you go much further:
 
 - Add filtering logic
 - Transform responses
@@ -12,7 +12,7 @@ Without Lua scripts, HappyView's query endpoints return raw records and procedur
 
 Scripts run in a sandboxed Lua VM with access to the [Record API](#record-api), a [database API](#database-api), an [HTTP client API](#http-api), a [JSON API](#json-api), and a set of [context globals](#context-globals).
 
-For scripts that react to record changes or label events (rather than XRPC requests), see [Record & Label Scripts](label-scripts).
+For scripts that react to record changes or label events (rather than XRPC requests), see [Record & Label Scripts](record-scripts).
 
 ## Script structure
 
@@ -256,7 +256,7 @@ See the example script references for complete, ready-to-use scripts:
 
 ## Next steps
 
-- [Record & Label Scripts](label-scripts): React to record changes and label events in real time
+- [Record & Label Scripts](record-scripts): React to record changes and label events in real time
 - [Lexicons](lexicons.md): Understand how record, query, and procedure lexicons work together
 - [Admin API — Scripts](../api-reference/admin/scripts.md): Manage scripts via the API
 - [XRPC API](../api-reference/xrpc-api.md): See how endpoints behave with and without Lua scripts

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -5,7 +5,7 @@
     "lexicons",
     "backfill",
     "background-jobs",
-    "label-scripts",
+    "record-scripts",
     "lua-scripting",
     "api-clients",
     "linked-repos",

--- a/packages/docs/content/docs/index.md
+++ b/packages/docs/content/docs/index.md
@@ -12,7 +12,7 @@ Building an AppView from scratch means wiring up real-time event streams, record
 
 - **Network sync built in:** Real-time record streaming via [Jetstream](https://github.com/bluesky-social/jetstream), historical [backfill](guides/backfill.md) from each user's PDS, and atproto OAuth with DPoP-bound proxy writes back to the PDS.
 
-- **Customize with Lua scripts and plugins:** Trigger-keyed [Lua scripts](guides/lua-scripting.md) for XRPC query/procedure logic and [record/label event handling](guides/label-scripts), WASM [plugins](guides/plugins.md) for external platform integration, and [labeler](guides/labelers.md) subscriptions for content moderation.
+- **Customize with Lua scripts and plugins:** Trigger-keyed [Lua scripts](guides/lua-scripting.md) for XRPC query/procedure logic and [record/label event handling](guides/record-scripts), WASM [plugins](guides/plugins.md) for external platform integration, and [labeler](guides/labelers.md) subscriptions for content moderation.
 
 - **Protocol-native:** Works with any PDS, resolves DIDs through the directory, and fetches [network lexicons](guides/lexicons.md#network-lexicons) via DNS authority resolution.
 
@@ -35,7 +35,7 @@ Building an AppView from scratch means wiring up real-time event streams, record
 - [Quickstart](getting-started/deployment/railway.md): Deploy HappyView on Railway or run it locally
 - [Lexicons](guides/lexicons.md): Upload lexicon schemas and start indexing records
 - [Lua Scripting](guides/lua-scripting.md): Write custom query and procedure logic
-- [Record & Label Scripts](guides/label-scripts): React to record changes and label events in real time
+- [Record & Label Scripts](guides/record-scripts): React to record changes and label events in real time
 - [Labelers](guides/labelers.md): Subscribe to external labelers and manage content labels
 - [Plugins](guides/plugins.md): Integrate with external platforms using WASM plugins
 - [Permissioned Spaces](experimental/spaces/index.md): Create membership-gated data containers with the atproto spaces API


### PR DESCRIPTION
Any mention to record/label scripts is linking to /guides/label-scripts instead of /guides/record-scripts. This PR fixes all the wrong links.

Fixes #92 