### PR TITLE
fix: show backfill switch when resolved lexicon is type record

### DIFF
--- a/web/src/app/dashboard/lexicons/new/page.tsx
+++ b/web/src/app/dashboard/lexicons/new/page.tsx
@@ -48,12 +48,15 @@ export default function AddLexiconPage() {
   const [resolving, setResolving] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
-  const mainType = resolved.nsid === nsid ? resolved.type : undefined;
   const networkJson = resolved.nsid === nsid ? resolved.json : "";
 
   const [lastValidType, setLastValidType] = useState<string | undefined>(
     undefined,
   );
+
+  const mainType = useMemo(() => {
+    return resolved.nsid === nsid ? resolved.type : undefined;
+  }, [resolved])
 
   const localMainType = useMemo(() => {
     try {
@@ -305,7 +308,18 @@ export default function AddLexiconPage() {
               )}
             </div>
 
-            <footer className="bg-sidebar-accent flex justify-end gap-2 ps-4 pt-2 pb-1 md:px-6 md:py-4 rounded-b-md">
+            <footer className="bg-sidebar-accent flex justify-end gap-6 ps-4 pt-2 pb-1 md:px-6 md:py-4 rounded-b-md">
+              {mainType === "record" && (
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="backfill">Enable backfill for lexicon</Label>
+                  <Switch
+                    id="backfill"
+                    checked={backfill}
+                    onCheckedChange={setBackfill}
+                  />
+                </div>
+              )}
+
               <Button onClick={handleAddNetwork} disabled={submitting}>
                 {submitting ? "Adding..." : "Add"}
               </Button>


### PR DESCRIPTION
The "Enable backfill for lexicon" switch toggle is being shown in the footer only when adding a local JSON, but not for a network lexicon

I changed `mainType` to update when `resolved` changes, so that the switch is only shown once the lexicon has been resolved (and it can check if it's of type record)

Fixes #94 